### PR TITLE
mod_auth_ldap2: import session into the profile.

### DIFF
--- a/lib/modules/mod_auth_ldap2.lua
+++ b/lib/modules/mod_auth_ldap2.lua
@@ -56,8 +56,9 @@ function new_default_provider(host)
      return nil, "Account creation/modification not available with LDAP.";
  end
 
- function provider.get_sasl_handler()
+ function provider.get_sasl_handler(session)
      local testpass_authentication_profile = {
+         session = session,     
          plain_test = function(sasl, username, password, realm)
              return provider.test_password(username, password), true;
          end,


### PR DESCRIPTION
Fixes traceback reported by user. Metronome now requires the profiles to always contain the user session state.